### PR TITLE
Fix permissions for backups

### DIFF
--- a/backup.tf
+++ b/backup.tf
@@ -25,7 +25,8 @@ data "aws_iam_policy_document" "backup" {
       "elasticfilesystem:Restore",
       "elasticfilesystem:CreateFilesystem",
       "elasticfilesystem:DescribeFilesystems",
-      "elasticfilesystem:DeleteFilesystem"
+      "elasticfilesystem:DeleteFilesystem",
+      "elasticfilesystem:DescribeTags"
     ]
 
     # This will not actually use the default file system, this just prevents various errors


### PR DESCRIPTION
Turns out that there is a new permission required,
`elasticfilesystem:DescribeTags`. Without that, backups fail with
message "Backup job failed because of insufficient privileges.".

Reference:
https://docs.aws.amazon.com/aws-backup/latest/devguide/security-iam-awsmanpol.html#w65aac24c15c15b7b9
(scroll down to `Amazon EFS Backup Policy`)