### PR TITLE
Support IAM permissions boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ module "efs" {
 | allowed\_cidrs | List of CIDRs permitted to access EFS mounts | `list(string)` | `[]` | no |
 | allowed\_security\_groups | List of Security Group IDs permitted to access EFS mounts | `list(string)` | `[]` | no |
 | backup\_kms\_key\_id | KMS Key to use for backups (Specify `aws/backup` to use the default key, leave null to have a key generated automatically) | `string` | `null` | no |
+| backup\_role\_permissions\_boundary | Optional [permissions boundary](https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_boundaries.html) ARN to use for the backup IAM role. | `string` | `null` | no |
 | backup\_schedule | Cron schedule to run backups on | `string` | `"cron(0 0 * * ? *)"` | no |
 | create | If `false`, this module does nothing | `bool` | `true` | no |
 | efs\_kms\_key\_id | ARN of KMS key to use for EFS encryption (leave null to create a key, set to `aws/backup` to use AWS default CMK) | `string` | `null` | no |

--- a/backup.tf
+++ b/backup.tf
@@ -63,8 +63,9 @@ resource "aws_iam_role" "backup" {
 
   name_prefix = substr("${var.name}-backup", 0, 32)
 
-  assume_role_policy = data.aws_iam_policy_document.assume_backup.json
-  tags               = var.additional_tags
+  assume_role_policy   = data.aws_iam_policy_document.assume_backup.json
+  permissions_boundary = var.backup_role_permissions_boundary
+  tags                 = var.additional_tags
 
   lifecycle {
     create_before_destroy = true

--- a/variables.tf
+++ b/variables.tf
@@ -93,3 +93,9 @@ variable "enable_backups" {
   description = "Should AWS Backup be configured for this file system?"
   type        = bool
 }
+
+variable "backup_role_permissions_boundary" {
+  default     = null
+  description = "An optional IAM permissions boundary to use when creating the IAM role for backups"
+  type        = string
+}


### PR DESCRIPTION
This adds support for specifying an IAM permissions boundary when
creating the IAM role for backups. It defaults to `null`, so it
is backwards-compatible.

* https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_boundaries.htm
* https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role#permissions_boundary