### PR TITLE
Allow configuring backup lifecycles

### DIFF
--- a/backup.tf
+++ b/backup.tf
@@ -107,6 +107,15 @@ resource "aws_backup_plan" "backup" {
     rule_name         = "${var.name}-cron-rule"
     target_vault_name = aws_backup_vault.backup[0].name
     schedule          = var.backup_schedule
+
+    dynamic "lifecycle" {
+      for_each = (var.backup_lifecycle_delete_after != null && var.backup_lifecycle_cold_storage_after != null) ? ["true"] : []
+
+      content {
+        delete_after       = var.backup_lifecycle_delete_after
+        cold_storage_after = var.backup_lifecycle_cold_storage_after
+      }
+    }
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -99,3 +99,15 @@ variable "backup_role_permissions_boundary" {
   description = "An optional IAM permissions boundary to use when creating the IAM role for backups"
   type        = string
 }
+
+variable "backup_lifecycle_delete_after" {
+  default     = null
+  description = "Specifies the number of days after creation that a recovery point is deleted. Must be 90 days greater than cold_storage_after."
+  type        = number
+}
+
+variable "backup_lifecycle_cold_storage_after" {
+  default     = null
+  description = "Specifies the number of days after creation that a recovery point is moved to cold storage."
+  type        = number
+}


### PR DESCRIPTION
This adds support for configuring lifecycles of backups.

Added two new variables, for the move to cold storage and permanent deletion. If both are set, the lifecycle of backup snapshots is configured.

Tested with tf 0.12.26

Fixes #10 