### PR TITLE
change lifecycle for_each from and to or

### DIFF
--- a/backup.tf
+++ b/backup.tf
@@ -109,7 +109,7 @@ resource "aws_backup_plan" "backup" {
     schedule          = var.backup_schedule
 
     dynamic "lifecycle" {
-      for_each = (var.backup_lifecycle_delete_after != null && var.backup_lifecycle_cold_storage_after != null) ? ["true"] : []
+      for_each = (var.backup_lifecycle_delete_after != null || var.backup_lifecycle_cold_storage_after != null) ? ["true"] : []
 
       content {
         delete_after       = var.backup_lifecycle_delete_after


### PR DESCRIPTION
Fixes #13 

I think the intended behavior was or, rather than and. The optimally configurable way is probably to create a variable of lifecycle objects which can be passed in and looped over.  The current solution is simpler though 