### PR TITLE
Add backup:TagResource permission to the backup IAM policy

### DIFF
--- a/backup.tf
+++ b/backup.tf
@@ -47,7 +47,8 @@ data "aws_iam_policy_document" "backup" {
 
     actions = [
       "backup:DescribeBackupVault",
-      "backup:CopyIntoBackupVault"
+      "backup:CopyIntoBackupVault",
+      "backup:TagResource"
     ]
 
     # This will not actually use the default file system, this just prevents various errors


### PR DESCRIPTION
AWS is notifying that:
> On June 30, 2025, we will be making a change to AWS Backup to validate the existence of the backup:TagResource permission when backup/copy job attempt to add tags to backups. [...] you must add the backup:TagResource permission to the roles used for backup/copy jobs by September 30, 2025, otherwise those jobs will start failing.

This pull request add the required permission to the IAM policy "backup"